### PR TITLE
Updated settings for generation of certificates

### DIFF
--- a/src/Frontend/Omnia.Fx.Demo/Resources/environment.manifest.ts
+++ b/src/Frontend/Omnia.Fx.Demo/Resources/environment.manifest.ts
@@ -1,10 +1,10 @@
 ﻿import { Composer, DevelopmentEnvironment} from '@omnia/fx/tooling';
-import {PFX_PASSWORD} from '../tools/configs.consts';
+import {pfxPassphrase} from '../tools/configs.consts';
 
 DevelopmentEnvironment.hosting
     .use({
         portNumber: 569,
         https: true,
         pfxPath: './tools/certificate.pfx',
-        pfxPassphrase: PFX_PASSWORD,
+        pfxPassphrase: pfxPassphrase,
     });

--- a/src/Frontend/Omnia.Fx.Demo/tools/generateCerts.js
+++ b/src/Frontend/Omnia.Fx.Demo/tools/generateCerts.js
@@ -19,9 +19,9 @@ const pfxPath = path.join(rootPath,"tools", "certificate.pfx");
  * If you want to use environment path to openssl you can 
  * uncomment below and point to the openssl binaries
  */
-pem.config({
-  pathOpenSSL: 'C:/Program Files/OpenSSL/bin/openssl.exe'
-});
+// pem.config({
+//   pathOpenSSL: 'C:/Program Files/OpenSSL/bin/openssl.exe'
+// });
 
 console.log("Generating Certs");
 createCertPr({

--- a/src/Frontend/Omnia.Fx.Demo/tools/generateCerts.js
+++ b/src/Frontend/Omnia.Fx.Demo/tools/generateCerts.js
@@ -7,13 +7,21 @@ const addCertToTrusted = require("./addCertToTrusted");
 const createCertPr = promisify(pem.createCertificate);
 const convertToPkc = promisify(pem.convert.PEM2PFX);
 
-const password = require("./configs.consts").PFX_PASSWORD;
+const password = require("./configs.consts").pfxPassphrase;
 const rootPath = process.cwd();
 
 const keyPath = path.join(rootPath, "tools", "key.pem");
 const certPath = path.join(rootPath, "tools", "cert.pem");
 const csrPath = path.join(rootPath, "tools", "csr.pem");
 const pfxPath = path.join(rootPath,"tools", "certificate.pfx");
+
+/**
+ * If you want to use environment path to openssl you can 
+ * uncomment below and point to the openssl binaries
+ */
+pem.config({
+  pathOpenSSL: 'C:/Program Files/OpenSSL/bin/openssl.exe'
+});
 
 console.log("Generating Certs");
 createCertPr({


### PR DESCRIPTION
The reference PFX_PASSWORD did not exist in the configs.consts file. Change the reference to existing pfxPassphrase instead. 
I also Added support to specify the path to the OpenSSL binaries to support generation of certificates without setting the environment variables. The OpenSSL binaries can be downloaded at: https://sourceforge.net/projects/openssl/